### PR TITLE
Modify the event API call limit to 5

### DIFF
--- a/client/src/components/Home/AboutUs/Event/Event.js
+++ b/client/src/components/Home/AboutUs/Event/Event.js
@@ -12,14 +12,10 @@ function Event({ page }) {
   const [isLoading, setIsLoading] = useState(true);
   useEffect(() => {
     axios
-      .get(`${process.env.REACT_APP_API || ""}/event`, {
-        options: {
-          limit:5
-        }
-      })
+      .get(`${process.env.REACT_APP_API || ""}/event`)
       .then((res) => {
         const { result } = res.data;
-        setEvent([...result]);
+        setEvent([...result].slice(0, 5));
         setIsLoading(false);
       })
       .catch((err) => {
@@ -43,7 +39,7 @@ function Event({ page }) {
               src={planet}
               className={`planet-img ${
                 page === "Home" ? "planet-img-home" : ""
-              }`}
+                }`}
               alt="planet"
             />
           )}
@@ -52,7 +48,7 @@ function Event({ page }) {
         <div
           className={`event-section col-11 col-md-8 ${
             page === "Home" ? "event-section-home" : ""
-          }`}
+            }`}
         >
           <div className="event-title">From the Geeks' Satellite..</div>
           <div className="event-content">


### PR DESCRIPTION
### Fixes - 1 fix, issue #231
<Do not delete this template>
Description: Modify the event API call limit to 5 events.

#### Checklist
- [x] I've followed the Contributing guidelines provided in the repository.
- [x] I've made the changes which were demanded in the linked issue.
- [x] I've tested my code on a Chromium based browser.
- [x] I've tested my code on Mozilla Firefox.
- [x] My code gave a clean console on debugging. (no warnings/errors)

#### Testimonial
The json data was already sorted from most current event to past so I just decided to limit the array size with the slice method. 
